### PR TITLE
Fix wrong route selection when lowest-return route is outlier

### DIFF
--- a/src/components/Aggregator/index.tsx
+++ b/src/components/Aggregator/index.tsx
@@ -666,10 +666,6 @@ export function AggregatorContainer({ tokenlist }) {
 		.filter((r) => r.gasUsd !== 'Unknown')
 		.concat(normalizedRoutes.filter((r) => r.gasUsd === 'Unknown'));
 
-	const minAmount = normalizedRoutes[normalizedRoutes.length - 1]?.amount;
-
-	normalizedRoutes = normalizedRoutes.filter(({ amount }) => amount < minAmount * 3);
-
 	const priceImpact =
 		fromTokenPrice && toTokenPrice && route?.route?.amountUsd > 0
 			? 100 - (route?.route?.amountUsd / (+fromTokenPrice * +amount)) * 100


### PR DESCRIPTION
Preview: https://llamaswap-interface-ev8zffpyz-shibacrypt.vercel.app/?chain=arbitrum&from=0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017&to=0xff970a61a04b1ca14834a43f5de4533ebddb5cc8

Case: Network = Arbitrum, Swap = 10000 RDNT -> USDC

We will be able to fetch these 5 routes
```
{route: {…}, gasUsd: 0.072730125, amountUsd: '412.39', amount: 411.982105, netOut: 412.31726987499997, …}
{route: {…}, gasUsd: 0.148914868775, amountUsd: '412.39', amount: 411.982105, netOut: 412.24108513122496, …}
{route: {…}, gasUsd: 0.0317401725, amountUsd: '412.20', amount: 411.78791, netOut: 412.1682598275, …}
{route: {…}, gasUsd: 0.30981317565, amountUsd: '412.39', amount: 411.982105, netOut: 412.08018682435, …}
{route: {…}, gasUsd: 0.155297714275, amountUsd: '32.71', amount: 32.682089, netOut: 32.554702285725, …}
```

But at the UI, the routes would only show 1 route
```
{route: {…}, gasUsd: 0.155297714275, amountUsd: '32.71', amount: 32.682089, netOut: 32.554702285725, …}
```

The cause of that is a `amount < minAmount * 3` filter on the routes fetched, where `minAmount` is defined as the `lowest-return amount`. This seems like a sanity check to make sure we don't wrongly include out-of-norm high-returns route. If we hit a set of routes whereby the lowest-return amount is an outlier than less than 3x of the other higher-return routes, then we would hit this case. 

I'd think that its fine to remove this filter to fix this issue because the false-positive impact isn't too huge. The most that can happen is error in swapping for the insane-high-returns route, which is simply a waste of gas.

If we want a sort of sanity amount check, I'd suggest that we could consider using an average or median of all the routes, and filter out those routes that fall under this amount.