### PR TITLE
Ethflow quoting

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -66,7 +66,7 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 			buyTokenBalance: 'erc20',
 			from: extra.userAddress,
 			//"priceQuality": "fast",
-			signingScheme: isEthflowOrder ? 'eip1272' : 'eip712', // for selling directly ether, another signature type is required
+			signingScheme: isEthflowOrder ? 'eip1271' : 'eip712', // for selling directly ether, another signature type is required
 			onchainOrder: isEthflowOrder ? true : false, // for selling directly ether, we have to quote for onchain orders
 			kind: 'sell',
 			sellAmountBeforeFee: amount

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -89,7 +89,6 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 	return {
 		amountReturned: expectedBuyAmount,
 		estimatedGas: isEthflowOrder ? 56360 : 0, // 56360 is gas from sending createOrder() tx
-		feeAmount: data.quote?.feeAmount, // even for ethflow orders, the normal fee has to be paid after onchain order placement costs
 		validTo: data.quote?.validTo || 0,
 		rawQuote: { ...data, slippage: extra.slippage },
 		tokenApprovalAddress: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',


### PR DESCRIPTION
Eth trading for cowswap is a special case. Instead of just handing in an eip712 signature, one has to create an ethereum transaction that places an EIP1271 order and send the eth along with this transaction.

One also has to create beforehand a quote that reflects this this will be an eip1271 order. This PR creates the necessary changes for it to work.
 - it quotes for an eip1271 order
 - it quotes for an on-chain order
 - it corrects the fee calculation
 - I ran: npx prettier --write ./src/components/Aggregator/adapters/cowswap/index.ts.
 
 
 This Pr is in draft status, as I might not be aware of some other tests or lints that I have not done. Please feel free to just use this logic from this PR and build a new PR from it.
 



