### PR TITLE
fix headers option in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,20 +11,27 @@ const nextConfig = {
 	compiler: {
 		styledComponents: true
 	},
-	headers: [
-		{
-			key: 'Access-Control-Allow-Origin',
-			value: '*'
-		},
-		{
-			key: 'Access-Control-Allow-Methods',
-			value: 'GET'
-		},
-		{
-			key: 'Access-Control-Allow-Headers',
-			value: 'X-Requested-With, content-type, Authorization'
-		}
-	],
+	async headers() {
+		return [
+			{
+				source: '/:path*',
+				headers: [
+					{
+						key: 'Access-Control-Allow-Origin',
+						value: '*'
+					},
+					{
+						key: 'Access-Control-Allow-Methods',
+						value: 'GET'
+					},
+					{
+						key: 'Access-Control-Allow-Headers',
+						value: 'X-Requested-With, content-type, Authorization'
+					}
+				]
+			}
+		];
+	},
 	experimental: {}
 };
 


### PR DESCRIPTION
Noticed this error in console when running `yarn dev`:

<img width="540" alt="" src="https://user-images.githubusercontent.com/1091472/215253470-490d24c7-18e8-412f-92b2-572242f3899f.png">

If we inspect the response header at https://swap.defillama.com/, you can find they weren't added:

<img width="609" alt="" src="https://user-images.githubusercontent.com/1091472/215253945-7b41f858-b6a4-41b5-9576-4bff9285cea7.png">

Hence I've updated the config accordingly per https://nextjs.org/docs/api-reference/next.config.js/headers.