### PR TITLE
remove z-index to make link clickable

### DIFF
--- a/src/components/Aggregator/RoutesPreview.tsx
+++ b/src/components/Aggregator/RoutesPreview.tsx
@@ -61,7 +61,7 @@ const CheckWithText = ({ text }: { text: string }) => {
 
 const RoutesPreview = () => {
 	return (
-		<Flex pt="30px" flexDir="column" justifyContent="space-around" h="100%" zIndex='-1'>
+		<Flex pt="30px" flexDir="column" justifyContent="space-around" h="100%">
 			<Header>
 				<MainIcon>{LlamaIcon}</MainIcon>
 


### PR DESCRIPTION
The `zIndex` code was introduced in https://github.com/LlamaSwap/interface/pull/44.

And it's causing the link to be unclickable at the moment:

![](https://user-images.githubusercontent.com/1091472/215311479-b32010a0-b755-4e24-beea-d75b847c66f8.png)

## how to reproduce

1. open https://swap.defillama.com/
2. Click `learn more` link