### PR TITLE
Disallow EthFlow Buy Orders

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -55,6 +55,13 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 	const tokenTo = to === ethers.constants.AddressZero ? nativeToken : to;
 	const tokenFrom = isEthflowOrder ? wrappedTokens[chain] : from;
 	const isBuyOrder = extra.amountOut && extra.amountOut !== '0';
+	
+	// Ethflow orders are always sell orders.
+	// Source: https://github.com/cowprotocol/ethflowcontract/blob/v1.0.0/src/libraries/EthFlowOrder.sol#L93-L95
+	if (isEthflowOrder && isBuyOrder) {
+		throw new Error('buy orders from Ether are not allowed');
+	}
+	
 	// amount should include decimals
 	const data = await fetch(`${chainToId[chain]}/api/v1/quote`, {
 		method: 'POST',


### PR DESCRIPTION
This PR adds a check to the CoW Swap adapter to disallow EthFlow buy orders. This is because the [contract only allows sell orders](https://github.com/cowprotocol/ethflowcontract/blob/v1.0.0/src/libraries/EthFlowOrder.sol#L93-L95):

```solidity
                // Only sell orders are allowed. In a buy order, any leftover ETH would stay in the ETH flow contract
                // and would need to be sent back to the user, whose extra gas cost is usually not worth it.
                GPv2Order.KIND_SELL, // bytes32 kind
```

The proposed fix is to throw an error when attempting to quote a buy order from Ether.