### PR TITLE
Update default block explorer for canto

### DIFF
--- a/src/components/WalletProvider/chains.ts
+++ b/src/components/WalletProvider/chains.ts
@@ -432,7 +432,7 @@ const canto = {
 		default: 'https://canto.neobase.one'
 	},
 	blockExplorers: {
-		default: { name: 'CantoScan', url: 'https://evm.explorer.canto.io' }
+		default: { name: 'CantoScan', url: 'https://tuber.build' }
 	},
 	testnet: false
 };


### PR DESCRIPTION
Canto doc recommends using `https://tuber.build/` or `https://cantoscan.xyz/` , see https://docs.canto.io/user-guides/connecting-to-canto. The `evm.explorer.canto.io` one is slow at indexing data.