### PR TITLE
load canto tokens from canto network repository

### DIFF
--- a/src/props/getTokenList.ts
+++ b/src/props/getTokenList.ts
@@ -62,7 +62,9 @@ export async function getTokenList() {
 		fetch('https://token-list.sushi.com/').then((r) => r.json()),
 		fetch('https://defillama-datasets.llama.fi/tokenlist/all.json').then((res) => res.json()),
 		fetch('https://defillama-datasets.llama.fi/tokenlist/logos.json').then((res) => res.json()),
-		fetch('https://raw.githubusercontent.com/0xngmi/tokenlists/master/canto.json').then((res) => res.json())
+		fetch('https://raw.githubusercontent.com/Canto-Network/list/main/lists/token-lists/mainnet/tokens.json').then((res) => res.json()).then(json => {
+			return json.filter((token: { symbol: string }) => token.symbol !== 'CANTO')
+		})
 	]);
 
 	const oneInchList = Object.values(oneInchChains)


### PR DESCRIPTION
Currently the code load canto tokens from https://github.com/0xngmi/tokenlists which I believe is a mirror of https://github.com/Canto-Network/list.

The problem here is if I want to add a new token, now I have to submit two pull requests against two repositories.

Reckon we can just load it from the canto network repository.