### PR TITLE
only allow valid decimals & use numberpad

### DIFF
--- a/src/components/InputAmountAndTokenSelect/index.tsx
+++ b/src/components/InputAmountAndTokenSelect/index.tsx
@@ -8,6 +8,8 @@ import { formatAmount } from '~/utils/formatAmount';
 import { PRICE_IMPACT_HIGH_THRESHOLD, PRICE_IMPACT_MEDIUM_THRESHOLD } from '../Aggregator/constants';
 import { TokenSelect } from './TokenSelect';
 
+const amountValidationRegex = /^[0-9]*\.?[0-9]*$/;
+
 export function InputAmountAndTokenSelect({
 	amount,
 	setAmount,
@@ -50,6 +52,13 @@ export function InputAmountAndTokenSelect({
 			? BigNumber(formatAmount(amount)).times(tokenPrice).toFixed(2)
 			: null;
 
+	const onValueChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+		const newValue = formatNumber(event.target.value.replace(/[^0-9.,]/g, '')?.replace(/,/g, '.'));
+		if (newValue !== '' && !amountValidationRegex.test(newValue)) return;
+
+		setAmount(type === 'amountOut' ? ['', newValue] : [newValue, '']);
+	};
+
 	return (
 		<Flex
 			flexDir="column"
@@ -70,6 +79,7 @@ export function InputAmountAndTokenSelect({
 					<Input
 						disabled={disabled}
 						type="text"
+						inputMode="decimal"
 						value={amount}
 						focusBorderColor="transparent"
 						border="none"
@@ -80,15 +90,7 @@ export function InputAmountAndTokenSelect({
 						p="0"
 						placeholder={(placeholder && String(placeholder)) || '0'}
 						_placeholder={{ color: '#5c5c5c' }}
-						onChange={(e) => {
-							const value = formatNumber(e.target.value.replace(/[^0-9.,]/g, '')?.replace(/,/g, '.'));
-
-							if (type === 'amountOut') {
-								setAmount(['', value]);
-							} else {
-								setAmount([value, '']);
-							}
-						}}
+						onChange={onValueChange}
 						overflow="hidden"
 						whiteSpace="nowrap"
 						textOverflow="ellipsis"
@@ -161,7 +163,7 @@ export function InputAmountAndTokenSelect({
 	);
 }
 
-function formatNumber(string) {
+function formatNumber(string: string) {
 	let pattern = /(?=(?!^)\d{3}(?:\b|(?:\d{3})+)\b)/g;
 	if (string.includes('.')) {
 		pattern = /(?=(?!^)\d{3}(?:\b|(?:\d{3})+)\b\.)/g;

--- a/src/components/InputAmountAndTokenSelect/index.tsx
+++ b/src/components/InputAmountAndTokenSelect/index.tsx
@@ -53,7 +53,7 @@ export function InputAmountAndTokenSelect({
 			: null;
 
 	const onValueChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-		const newValue = formatNumber(event.target.value.replace(/[^0-9.,]/g, '')?.replace(/,/g, '.'));
+		const newValue = event.target.value.replace(/[^0-9.,]/g, '')?.replace(/,/g, '.');
 		if (newValue !== '' && !amountValidationRegex.test(newValue)) return;
 
 		setAmount(type === 'amountOut' ? ['', newValue] : [newValue, '']);
@@ -161,12 +161,4 @@ export function InputAmountAndTokenSelect({
 			</Flex>
 		</Flex>
 	);
-}
-
-function formatNumber(string: string) {
-	let pattern = /(?=(?!^)\d{3}(?:\b|(?:\d{3})+)\b)/g;
-	if (string.includes('.')) {
-		pattern = /(?=(?!^)\d{3}(?:\b|(?:\d{3})+)\b\.)/g;
-	}
-	return string.replace(pattern, ' ');
 }


### PR DESCRIPTION
1. only allow valid decimal as input amount
addresses https://github.com/LlamaSwap/interface/issues/121

2. uses numberpad keyboard on mobile instead of full keyboard

before:
https://bafybeia276gxpxouggh4jmyn76ejv3mehzsh35tsqxro7b3qh36ui4diga.ipfs.w3s.link/keyboard-before.jpg

after:
https://bafybeig2l747svyrlnle6p7b34a2j3jckthjaj4wdu2l7tstotgwbgs2rq.ipfs.w3s.link/keyboard-after.jpeg