### PR TITLE
Convert CoW Swap orders to zero signed fee orders

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -128,10 +128,10 @@ export async function swap({ chain, signer, rawQuote, from, to }) {
 			[
 				to,
 				fromAddress,
-				rawQuote.quote.sellAmount,
+				BigNumber(rawQuote.quote.sellAmount).plus(rawQuote.quote.feeAmount).toFixed(0),
 				rawQuote.quote.buyAmount,
 				rawQuote.quote.appData,
-				rawQuote.quote.feeAmount,
+				0,
 				rawQuote.quote.validTo,
 				rawQuote.quote.partiallyFillable,
 				rawQuote.id
@@ -144,12 +144,12 @@ export async function swap({ chain, signer, rawQuote, from, to }) {
 		const order = {
 			sellToken: rawQuote.quote.sellToken,
 			buyToken: rawQuote.quote.buyToken,
-			sellAmount: rawQuote.quote.sellAmount,
+			sellAmount: BigNumber(rawQuote.quote.sellAmount).plus(rawQuote.quote.feeAmount).toFixed(0),
 			buyAmount: rawQuote.quote.buyAmount,
 			validTo: rawQuote.quote.validTo,
 			appData: rawQuote.quote.appData,
 			receiver: fromAddress,
-			feeAmount: rawQuote.quote.feeAmount,
+			feeAmount: 0,
 			kind: rawQuote.quote.kind,
 			partiallyFillable: rawQuote.quote.partiallyFillable
 		};


### PR DESCRIPTION
This PR proposes to make all orders placed on CoW Swap via DefiLlama as zero-signed fee orders, thus allowing for the solvers operating on CoW Protocol to propose a dynamic fee, based on the current state of the CoW Protocol orderbook and network conditions. This will allow solvers to more easily push additional benefits of batching to users, compared to a static fee (which is the case today).

We stress that nothing wrt to quotes and the limit price users sign will change, i.e., users will sign a limit price that is exactly equal to what they would sign prior this change.