### PR TITLE
fix: preserve query params when switching chain

### DIFF
--- a/src/components/Aggregator/index.tsx
+++ b/src/components/Aggregator/index.tsx
@@ -592,7 +592,7 @@ export function AggregatorContainer({ tokenList, sandwichList }) {
 			.push(
 				{
 					pathname: '/',
-					query: { chain: newChain.value, from: ethers.constants.AddressZero }
+					query: { ...router.query, chain: newChain.value, from: ethers.constants.AddressZero, to: undefined }
 				},
 				undefined,
 				{ shallow: true }

--- a/src/hooks/useQueryParams.tsx
+++ b/src/hooks/useQueryParams.tsx
@@ -11,7 +11,7 @@ export function useQueryParams() {
 	const { isConnected } = useAccount();
 	const { chain: chainOnWallet } = useNetwork();
 
-	const { chain: chainOnURL, from: fromToken, to: toToken } = router.query;
+	const { chain: chainOnURL, from: fromToken, to: toToken, ...query } = router.query;
 
 	const chainName = typeof chainOnURL === 'string' ? chainOnURL.toLowerCase() : 'ethereum';
 	const fromTokenAddress = typeof fromToken === 'string' ? fromToken.toLowerCase() : null;
@@ -26,7 +26,7 @@ export function useQueryParams() {
 				router.push(
 					{
 						pathname: '/',
-						query: { chain: chain.value, from: ethers.constants.AddressZero }
+						query: { ...query, chain: chain.value, from: ethers.constants.AddressZero }
 					},
 					undefined,
 					{ shallow: true }
@@ -36,7 +36,7 @@ export function useQueryParams() {
 				router.push(
 					{
 						pathname: '/',
-						query: { chain: 'ethereum', from: ethers.constants.AddressZero }
+						query: { ...query, chain: 'ethereum', from: ethers.constants.AddressZero }
 					},
 					undefined,
 					{ shallow: true }


### PR DESCRIPTION
`mode` query param wasn't preserved when switching chain, so the theme would reset to the default value.

This ensures we're preserving the interesting query params (except `to` as the target token address may be different on another chain)