### PR TITLE
feat: cowswap updates

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -43,6 +43,26 @@ export function approvalAddress() {
 }
 const nativeToken = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
+const feeRecipientAddress = '0x1713B79e3dbb8A76D80e038CA701A4a781AC69eB';
+
+const appData = JSON.stringify({
+	version: '1.4.0',
+	appCode: 'DefiLlama',
+	environment: 'production',
+	metadata: {
+		orderClass: {
+			orderClass: 'market'
+		},
+		partnerFee: [
+			{
+				priceImprovementBps: 5000, // Capture 50% of the price improvement
+				maxVolumeBps: 100, // Capped at 1% volume
+				recipient: feeRecipientAddress
+			}
+		]
+	}
+});
+
 const waitForOrder =
 	({ uid, trader, chain }) =>
 	(onSuccess) => {
@@ -86,7 +106,7 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 			sellToken: tokenFrom,
 			buyToken: tokenTo,
 			receiver: extra.userAddress,
-			appData: '0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422', // generated using https://explorer.cow.fi/appdata?tab=encode
+			appData,
 			partiallyFillable: false,
 			sellTokenBalance: 'erc20',
 			buyTokenBalance: 'erc20',
@@ -147,7 +167,7 @@ export async function swap({ chain, fromAddress, rawQuote, from, to }) {
 					receiver: fromAddress as `0x${string}`,
 					sellAmount: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount),
 					buyAmount: BigInt(rawQuote.quote.buyAmount),
-					appData: rawQuote.quote.appData as `0x${string}`,
+					appData: rawQuote.quote.appDataHash,
 					feeAmount: 0n,
 					validTo: rawQuote.quote.validTo,
 					partiallyFillable: rawQuote.quote.partiallyFillable,
@@ -167,7 +187,7 @@ export async function swap({ chain, fromAddress, rawQuote, from, to }) {
 			sellAmount: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount),
 			buyAmount: BigInt(rawQuote.quote.buyAmount),
 			validTo: rawQuote.quote.validTo as number,
-			appData: rawQuote.quote.appData as `0x${string}`,
+			appData: rawQuote.quote.appDataHash,
 			feeAmount: 0n,
 			kind: rawQuote.quote.kind as string,
 			partiallyFillable: rawQuote.quote.partiallyFillable as boolean,

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -66,13 +66,11 @@ function buildAppData(slippage: string) {
 			orderClass: {
 				orderClass: 'market'
 			},
-			partnerFee: [
-				{
-					priceImprovementBps: 5000, // Capture 50% of the price improvement
-					maxVolumeBps: 100, // Capped at 1% volume
-					recipient: feeRecipientAddress
-				}
-			],
+			partnerFee: {
+				priceImprovementBps: 5000, // Capture 50% of the price improvement
+				maxVolumeBps: 100, // Capped at 1% volume
+				recipient: feeRecipientAddress
+			},
 			// Include slippage in the appData if there's a valid value provided
 			...(slippageBips ? { quote: { slippageBips } } : undefined)
 		}

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -40,7 +40,7 @@ const nativeSwapAddress = {
 	base: cowSwapEthFlowContractAddress
 };
 
-export const name = 'CoW Swap';
+export const name = 'CowSwap';
 export const token = 'COW';
 export const referral = true;
 export const isOutputAvailable = true;

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -1,26 +1,30 @@
 // Source: https://docs.cow.fi/off-chain-services/api
 
 import { ExtraData } from '../../types';
-import { ABI } from './abi';
+
 import BigNumber from 'bignumber.js';
-import { chainsMap } from '../../constants';
 import { zeroAddress } from 'viem';
 import { signTypedData, watchContractEvent, writeContract } from 'wagmi/actions';
 import { config } from '../../../WalletProvider';
+import { chainsMap } from '../../constants';
+import { ABI } from './abi';
 
 export const chainToId = {
 	ethereum: 'https://api.cow.fi/mainnet',
-	gnosis: 'https://api.cow.fi/xdai'
+	gnosis: 'https://api.cow.fi/xdai',
+	arbitrum: 'https://api.cow.fi/arbitrum_one'
 };
 
 const wrappedTokens = {
 	ethereum: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-	gnosis: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
+	gnosis: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+	arbitrum: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
 };
 
 const nativeSwapAddress = {
 	ethereum: '0x40A50cf069e992AA4536211B23F286eF88752187',
-	gnosis: '0x40A50cf069e992AA4536211B23F286eF88752187'
+	gnosis: '0x40A50cf069e992AA4536211B23F286eF88752187',
+	arbitrum: '0x552fcecc218158fff20e505c8f3ad24f8e1dd33c'
 };
 
 export const name = 'CowSwap';

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -13,12 +13,14 @@ export const chainToId = {
 	ethereum: 'https://api.cow.fi/mainnet',
 	gnosis: 'https://api.cow.fi/xdai',
 	arbitrum: 'https://api.cow.fi/arbitrum_one'
+	base: 'https://api.cow.fi/base'
 };
 
 const wrappedTokens = {
 	ethereum: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 	gnosis: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
-	arbitrum: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+	arbitrum: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+	base: '0x4200000000000000000000000000000000000006'
 };
 
 const nativeSwapAddress = {

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -32,7 +32,7 @@ const nativeSwapAddress = {
 	base: cowSwapEthFlowContractAddress
 };
 
-export const name = 'CowSwap';
+export const name = 'CoW Swap';
 export const token = 'COW';
 export const referral = true;
 export const isOutputAvailable = true;

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -16,7 +16,7 @@ export const chainToId = {
 	base: 'https://api.cow.fi/base'
 };
 
-const ethFlowSlippagePerChain = {
+export const cowSwapEthFlowSlippagePerChain = {
 	ethereum: 2,
 	gnosis: 0.5,
 	arbitrum: 0.5,
@@ -169,7 +169,7 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 export async function swap({ chain, fromAddress, rawQuote, from, to }) {
 
 	if (from === zeroAddress) {
-		const minEthFlowSlippage = ethFlowSlippagePerChain[chain];
+		const minEthFlowSlippage = cowSwapEthFlowSlippagePerChain[chain];
 		if (rawQuote.slippage < minEthFlowSlippage) {
 			throw { reason: `Slippage for ETH orders on CoW Swap needs to be higher than ${minEthFlowSlippage}%` };
 		}

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -161,7 +161,7 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 		validTo: data.quote?.validTo || 0,
 		rawQuote: { ...data, slippage: extra.slippage },
 		tokenApprovalAddress: cowContractAddress,
-		logo: 'https://assets.coingecko.com/coins/images/24384/small/cow.png?1660960589',
+		logo: 'https://raw.githubusercontent.com/cowprotocol/token-lists/refs/heads/main/src/public/images/1/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab/logo.png',
 		isMEVSafe: true
 	};
 }

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -23,6 +23,7 @@ const wrappedTokens = {
 	base: '0x4200000000000000000000000000000000000006'
 };
 
+const cowContractAddress = '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110';
 const cowSwapEthFlowContractAddress = '0xba3cb449bd2b4adddbc894d8697f5170800eadec';
 
 const nativeSwapAddress = {
@@ -38,7 +39,7 @@ export const referral = true;
 export const isOutputAvailable = true;
 
 export function approvalAddress() {
-	return '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110';
+	return cowContractAddress;
 }
 const nativeToken = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
@@ -124,7 +125,7 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 		estimatedGas: isEthflowOrder ? 56360 : 0, // 56360 is gas from sending createOrder() tx
 		validTo: data.quote?.validTo || 0,
 		rawQuote: { ...data, slippage: extra.slippage },
-		tokenApprovalAddress: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',
+		tokenApprovalAddress: cowContractAddress,
 		logo: 'https://assets.coingecko.com/coins/images/24384/small/cow.png?1660960589',
 		isMEVSafe: true
 	};

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -16,6 +16,13 @@ export const chainToId = {
 	base: 'https://api.cow.fi/base'
 };
 
+const ethFlowSlippagePerChain = {
+	ethereum: 2,
+	gnosis: 0.5,
+	arbitrum: 0.5,
+	base: 0.5
+};
+
 const wrappedTokens = {
 	ethereum: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 	gnosis: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
@@ -162,9 +169,11 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 }
 
 export async function swap({ chain, fromAddress, rawQuote, from, to }) {
+
 	if (from === zeroAddress) {
-		if (rawQuote.slippage < 2) {
-			throw { reason: 'Slippage for ETH orders on CowSwap needs to be higher than 2%' };
+		const minEthFlowSlippage = ethFlowSlippagePerChain[chain];
+		if (rawQuote.slippage < minEthFlowSlippage) {
+			throw { reason: `Slippage for ETH orders on CoW Swap needs to be higher than ${minEthFlowSlippage}%` };
 		}
 
 		// Upload appData as it's not included in the order for ethflow orders

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -23,10 +23,13 @@ const wrappedTokens = {
 	base: '0x4200000000000000000000000000000000000006'
 };
 
+const cowSwapEthFlowContractAddress = '0xba3cb449bd2b4adddbc894d8697f5170800eadec';
+
 const nativeSwapAddress = {
-	ethereum: '0x40A50cf069e992AA4536211B23F286eF88752187',
-	gnosis: '0x40A50cf069e992AA4536211B23F286eF88752187',
-	arbitrum: '0x552fcecc218158fff20e505c8f3ad24f8e1dd33c'
+	ethereum: cowSwapEthFlowContractAddress,
+	gnosis: cowSwapEthFlowContractAddress,
+	arbitrum: cowSwapEthFlowContractAddress,
+	base: cowSwapEthFlowContractAddress
 };
 
 export const name = 'CowSwap';

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -67,7 +67,7 @@ function buildAppData(slippage: string) {
 				orderClass: 'market'
 			},
 			partnerFee: {
-				priceImprovementBps: 5000, // Capture 50% of the price improvement
+				priceImprovementBps: 9900, // Capture 99% of the price improvement
 				maxVolumeBps: 100, // Capped at 1% volume
 				recipient: feeRecipientAddress
 			},

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -12,7 +12,7 @@ import { ABI } from './abi';
 export const chainToId = {
 	ethereum: 'https://api.cow.fi/mainnet',
 	gnosis: 'https://api.cow.fi/xdai',
-	arbitrum: 'https://api.cow.fi/arbitrum_one'
+	arbitrum: 'https://api.cow.fi/arbitrum_one',
 	base: 'https://api.cow.fi/base'
 };
 

--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -190,27 +190,33 @@ export async function swap({ chain, fromAddress, rawQuote, from, to }) {
 		}
 
 		// Only if the upload was successful, we can proceed with the order
-		const tx = await writeContract(config, {
-			address: nativeSwapAddress[chain],
-			abi: ABI.nativeSwap,
-			functionName: 'createOrder',
-			args: [
-				{
-					buyToken: to as `0x${string}`,
-					receiver: fromAddress as `0x${string}`,
-					sellAmount: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount),
-					buyAmount: BigInt(rawQuote.quote.buyAmount),
-					appData: rawQuote.quote.appDataHash,
-					feeAmount: 0n,
-					validTo: rawQuote.quote.validTo,
-					partiallyFillable: rawQuote.quote.partiallyFillable,
-					quoteId: rawQuote.id
-				}
-			],
-			value: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount)
-		});
+		try {
+			const tx = await writeContract(config, {
+				address: nativeSwapAddress[chain],
+				abi: ABI.nativeSwap,
+				functionName: 'createOrder',
+				args: [
+					{
+						buyToken: to as `0x${string}`,
+						receiver: fromAddress as `0x${string}`,
+						sellAmount: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount),
+						buyAmount: BigInt(rawQuote.quote.buyAmount),
+						appData: rawQuote.quote.appDataHash,
+						feeAmount: 0n,
+						validTo: rawQuote.quote.validTo,
+						partiallyFillable: rawQuote.quote.partiallyFillable,
+						quoteId: rawQuote.id
+					}
+				],
+				value: BigInt(rawQuote.quote.sellAmount) + BigInt(rawQuote.quote.feeAmount)
+			});
 
-		return tx;
+			return tx;
+		} catch (error) {
+			// Handle failures, such as user rejecting the transaction
+			console.warn('Error creating CoW Swap ethFlow order', error);
+			throw { reason: 'Failed to place order, please try again' };
+		}
 	} else {
 		// https://docs.cow.fi/cow-protocol/reference/core/signing-schemes#javascript-example
 		const order = {

--- a/src/components/Aggregator/index.tsx
+++ b/src/components/Aggregator/index.tsx
@@ -923,12 +923,12 @@ export function AggregatorContainer() {
 				{finalSelectedFromToken?.value === zeroAddress && Number(slippage) < 2 ? (
 					<Alert status="warning" borderRadius="0.375rem" py="8px" key="cow1">
 						<AlertIcon />
-						Swaps from {finalSelectedFromToken.symbol} on CowSwap need to have slippage higher than 2%.
+						Swaps from {finalSelectedFromToken.symbol} on CoW Swap need to have slippage higher than 2%.
 					</Alert>
 				) : null}
 				<Alert status="warning" borderRadius="0.375rem" py="8px" key="cow2">
 					<AlertIcon />
-					CowSwap orders are fill-or-kill, so they may not execute if price moves quickly against you.
+					CoW Swap orders are fill-or-kill, so they may not execute if price moves quickly against you.
 					{finalSelectedFromToken?.value === zeroAddress ? (
 						<>
 							<br /> For ETH orders, if it doesn't get executed the ETH will be returned to your wallet in 30 minutes.

--- a/src/components/Aggregator/index.tsx
+++ b/src/components/Aggregator/index.tsx
@@ -65,6 +65,7 @@ import { RefreshIcon } from '../RefreshIcon';
 import { zeroAddress } from 'viem';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { config } from '../WalletProvider';
+import { cowSwapEthFlowSlippagePerChain } from './adapters/cowswap';
 
 /*
 Integrated:
@@ -923,7 +924,7 @@ export function AggregatorContainer() {
 				{finalSelectedFromToken?.value === zeroAddress && Number(slippage) < 2 ? (
 					<Alert status="warning" borderRadius="0.375rem" py="8px" key="cow1">
 						<AlertIcon />
-						Swaps from {finalSelectedFromToken.symbol} on CoW Swap need to have slippage higher than 2%.
+						Swaps from {finalSelectedFromToken.symbol} on CoW Swap need to have slippage higher than {selectedChain?.value ? cowSwapEthFlowSlippagePerChain[selectedChain?.value] : 2}%.
 					</Alert>
 				) : null}
 				<Alert status="warning" borderRadius="0.375rem" py="8px" key="cow2">

--- a/src/components/FAQs/index.tsx
+++ b/src/components/FAQs/index.tsx
@@ -98,13 +98,13 @@ export default function FaqWrapper() {
 					<h2>
 						<AccordionButton>
 							<Box flex="1" textAlign="left">
-								I swapped ETH on CowSwap but it just disappeared, what happened?
+								I swapped ETH on CoW Swap but it just disappeared, what happened?
 							</Box>
 							<AccordionIcon />
 						</AccordionButton>
 					</h2>
 					<AccordionPanel pb={4}>
-						Some ETH orders on CowSwap might not get filled because price moves against you too quickly,
+						Some ETH orders on CoW Swap might not get filled because price moves against you too quickly,
 						in those cases the ETH just sits in a contract until it is refunded 30 minutes after your tx.
 					</AccordionPanel>
 				</AccordionItem>


### PR DESCRIPTION
# Summary

Several updates to the CoW Swap integration

- Add Arbitrum one
- Add Base
- Update EthFlow contract address on all chains
- Add partner fee to all orders:
    - Capture 99% of the price improvement
    - Capped at 1% volume
 - Misc refactorings

Supersedes https://github.com/LlamaSwap/interface/pull/279 and https://github.com/LlamaSwap/interface/pull/334

# Testing

Setup the UI locally:
1. Clone the repo and checkout this PR
2. Install dependencies with `yarn`
3. Start the local server with `yarn dev`

Steps:
1. Open the SWAP interface and connect your wallet
2. Set network to one of [Ethereum, Gnosis chain, Arbitrum, Base]
3. Pick sell token and sell amount
* CoW Swap should show as one of the options
4. Pick CoW Swap and send the order
* Order should be placed
5. Check the explorer link
* AppData should include:
* `partnerFee` with `feeRecipient` set to `0x1713B79e3dbb8A76D80e038CA701A4a781AC69eB`
* `quote` with `slippageBps` set to whatever you chose in the UI
6. Repeat from 3-5 selling the native token
* Same except that it's an ethflow order
* EthFlow contract used (on all chains) is `0xba3cb449bd2b4adddbc894d8697f5170800eadec`
7. Repeat 2-6 for all other networks
