### PR TITLE
feat: add new networks to cowswap

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -13,21 +13,27 @@ export const chainToId = {
 	ethereum: 'https://api.cow.fi/mainnet',
 	gnosis: 'https://api.cow.fi/xdai',
 	arbitrum: 'https://api.cow.fi/arbitrum_one',
-	base: 'https://api.cow.fi/base'
+	base: 'https://api.cow.fi/base',
+	avax: 'https://api.cow.fi/avalanche',
+	polygon: 'https://api.cow.fi/polygon'
 };
 
 export const cowSwapEthFlowSlippagePerChain = {
 	ethereum: 2,
 	gnosis: 0.5,
 	arbitrum: 0.5,
-	base: 0.5
+	base: 0.5,
+	avax: 0.5,
+	polygon: 0.5
 };
 
 const wrappedTokens = {
 	ethereum: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 	gnosis: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
 	arbitrum: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-	base: '0x4200000000000000000000000000000000000006'
+	base: '0x4200000000000000000000000000000000000006',
+	avax: '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7',
+	polygon: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
 };
 
 const cowContractAddress = '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110';
@@ -37,7 +43,9 @@ const nativeSwapAddress = {
 	ethereum: cowSwapEthFlowContractAddress,
 	gnosis: cowSwapEthFlowContractAddress,
 	arbitrum: cowSwapEthFlowContractAddress,
-	base: cowSwapEthFlowContractAddress
+	base: cowSwapEthFlowContractAddress,
+	avax: cowSwapEthFlowContractAddress,
+	polygon: cowSwapEthFlowContractAddress
 };
 
 export const name = 'CowSwap';


### PR DESCRIPTION
# Summary
## Adding new networks to the CoW Swap integration

- Add Avalanche
- Add Polygon

![Screenshot 2025-06-23 at 14 08 55](https://github.com/user-attachments/assets/bfa8bd5f-d881-40df-813e-514ea0b2b368)

![Screenshot 2025-06-23 at 15 30 25](https://github.com/user-attachments/assets/6d6007fd-fc71-4fe8-bd49-e0016c899520)


## Testing

Setup the UI locally:

1. Clone the repo and checkout this PR
2. Install dependencies with `yarn`
3. Start the local server with `yarn dev`

Steps:

1. Open the SWAP interface and connect your wallet
2. Set network to one of [Avalanche, Polygon]
3. Pick sell token and sell amount
4. CoW Swap should show as one of the options
5. Pick CoW Swap and send the order
6. Order should be placed
7. Check the explorer link
8. AppData should include:
9. partnerFee with feeRecipient set to `0x1713B79e3dbb8A76D80e038CA701A4a781AC69eB`
10. quote with slippageBps set to whatever you chose in the UI
11. Repeat from 3-5 selling the native token
12. Same except that it's an ethflow order
13. EthFlow contract used (on all chains) is `0xba3cb449bd2b4adddbc894d8697f5170800eadec`
14. Repeat 2-6 for the other network

