### PR TITLE
feat: prevent cowswap orders with slippage outside the expected range

### DIFF
--- a/src/components/Aggregator/adapters/cowswap/index.ts
+++ b/src/components/Aggregator/adapters/cowswap/index.ts
@@ -167,6 +167,9 @@ export async function getQuote(chain: string, from: string, to: string, amount: 
 }
 
 export async function swap({ chain, fromAddress, rawQuote, from, to, isSmartContractWallet }) {
+	if (rawQuote.slippage < 0 || rawQuote.slippage >= 100) {
+		throw { reason: 'Invalid slippage. Please set a slippage between 0 and 99.99%' };
+	}
 
 	if (from === zeroAddress) {
 		const minEthFlowSlippage = cowSwapEthFlowSlippagePerChain[chain];


### PR DESCRIPTION
# Summary

Limit slippage for CoW Swap orders to the range: 0 < slippage >=100

Example order coming from Defillama integration with 100% slippage https://api.cow.fi/base/api/v1/orders/0xfcbd64398f0a03405b4c37f356a36bc0acc538fa144f67a9471bafd905712d62ba3cb449bd2b4adddbc894d8697f5170800eadecffffffff

That is not good as 100% slippage is not a valid case, and orders like this will never settle.
Additionally, since this is an eth-flow order, it will not be automatically refunded due to invalid parameters, requiring manual intervention to recover user's funds.

# Testing

1. Load the app and fill in the trade details
2. Set slippage to 100%
3. Connect wallet
4. Pick `CoW Swap`
5. Click on place the order
* Order should not be allowed
![image](https://github.com/user-attachments/assets/db6d3a5d-6904-429b-8a4f-14726ddc2b67)
