### PR TITLE
feat: add decimal mode to inputs

### DIFF
--- a/src/components/InputAmountAndTokenSelect/index.tsx
+++ b/src/components/InputAmountAndTokenSelect/index.tsx
@@ -111,6 +111,7 @@ export function InputAmountAndTokenSelect({
 				<Box pos="relative">
 					<StyledInput
 						type="text"
+						inputMode="decimal"
 						value={amount}
 						placeholder={(placeholder && String(placeholder)) || '0'}
 						onChange={(e) => {

--- a/src/components/Slippage/index.tsx
+++ b/src/components/Slippage/index.tsx
@@ -65,6 +65,7 @@ export function Slippage({ slippage, setSlippage, fromToken, toToken }) {
 				<input
 					value={slippage}
 					type="text"
+					inputMode="decimal"
 					style={{
 						width: '100%',
 						height: '2rem',


### PR DESCRIPTION
This smol change allows for a better mobile UX, as it pops up the numeric keyboard on instead of qwerty by default, without blocking anything (no reason to enter string into a numeric only field (`fromAmount`/`toAmount`/`slippage`).